### PR TITLE
Added a test case for where observation order in distinct implementation matters

### DIFF
--- a/src/Test/StateTest.hs
+++ b/src/Test/StateTest.hs
@@ -180,7 +180,7 @@ distinctTest =
         , testProperty "Every element repeated" $ \xs ->
             distinct (xs :: List Integer) == distinct (flatMap (\x -> x :. x :. Nil) xs)
         , testProperty "Order is from left to right" $ \xs ->
-            distinct (xs :: List Integer) == distinct (flatMap (\x -> x :. x :. Nil) xs)
+            distinct (xs :: List Integer) == distinct xs
         ]
 
 isHappyTest :: TestTree

--- a/src/Test/StateTest.hs
+++ b/src/Test/StateTest.hs
@@ -173,9 +173,13 @@ distinctTest =
             let cs = listh ['a' .. 'z'] in distinct cs @?= cs
         , testCase "Every element repeated" $
             let cs = listh ['a' .. 'z'] in distinct (flatMap (\x -> x :. x :. Nil) cs) @?= cs
+        , testCase "Elements repeated, order matters" $
+            let cs = listh [1, 1, 2, 3, 2] in distinct cs @?= listh [1, 2, 3]
         , testProperty "No repeats after distinct" $ \xs ->
             firstRepeat (distinct (xs :: List Integer)) == Empty
         , testProperty "Every element repeated" $ \xs ->
+            distinct (xs :: List Integer) == distinct (flatMap (\x -> x :. x :. Nil) xs)
+        , testProperty "Order is from left to right" $ \xs ->
             distinct (xs :: List Integer) == distinct (flatMap (\x -> x :. x :. Nil) xs)
         ]
 

--- a/src/Test/StateTest.hs
+++ b/src/Test/StateTest.hs
@@ -179,8 +179,6 @@ distinctTest =
             firstRepeat (distinct (xs :: List Integer)) == Empty
         , testProperty "Every element repeated" $ \xs ->
             distinct (xs :: List Integer) == distinct (flatMap (\x -> x :. x :. Nil) xs)
-        , testProperty "Order is from left to right" $ \xs ->
-            distinct (xs :: List Integer) == distinct xs
         ]
 
 isHappyTest :: TestTree


### PR DESCRIPTION
If an implementation is accidentally folding right instead of left `distinct $ [1, 1, 2, 3, 2]` will produce `[1, 3, 2]` instead of the expected `[1, 2, 3]`.